### PR TITLE
appendix sec/subsection redefinition

### DIFF
--- a/these-ISSS.cls
+++ b/these-ISSS.cls
@@ -1063,9 +1063,9 @@
 					\setcounter{section}{0}%
 					\renewcommand\@chapapp{\appendixname}%
 					\renewcommand\thechapter{\@Alph\c@chapter}
-					\renewcommand\thesection{\@Alph\c@section}
-					\renewcommand\thesubsection{\@Alph\c@section.\@arabic\c@subsection}}
-				
+					\renewcommand\thesection{\@Alph\c@chapter.\@arabic\c@section}
+					\renewcommand\thesubsection{\@Alph\c@chapter.\@arabic\c@section.\@arabic\c@subsection}}
+
 				\setlength\arraycolsep{5\p@}
 				\setlength\tabcolsep{6\p@}
 				\setlength\arrayrulewidth{.4\p@}


### PR DESCRIPTION
i.e \renewcommand\thesection{\@Alph\c@chapter.\@arabic\c@section}
solves #7 

example after change:
![after](https://github.com/mpelleau/these-I3S/assets/19288968/2831ec07-254b-4ac5-936c-3c8e35c93d8b)
before:
![before](https://github.com/mpelleau/these-I3S/assets/19288968/57c2f416-8ea1-404d-8041-fe69f05b17d1)
